### PR TITLE
Stop deleting .git folder

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -491,3 +491,22 @@ input[type="text"] {
     border: 2px solid var(--black);
 }
 /* End of the style for the button (left side of the bottom button) */
+
+/* Style for the alert box */
+.alterbox {
+    display: flex;
+    flex-direction: row;
+    background-color: var(--red);
+    color: var(--text-color);
+    border-radius: 10px;
+    align-items: center;
+    justify-content: center;
+}
+
+.alterbox a {
+    color: var(--text-color);
+    margin: 20px;
+    background-color: transparent;
+    border: none;
+}
+/* End style for the alert box */

--- a/css/theme.css
+++ b/css/theme.css
@@ -18,6 +18,7 @@
     --white: #fff;
     --black: #000;
     --black-low-opacity: rgba(0, 0, 0, 0.1);
+    --red: #ff0000;
     /* end of standard colors */
 }
 

--- a/data/version.json
+++ b/data/version.json
@@ -1,4 +1,4 @@
 {
     "version": "0.2",
-    "theme": "dark"
+    "theme": "light"
 }

--- a/index.php
+++ b/index.php
@@ -45,6 +45,14 @@ $localData = getJsonFromFile("data/version.json");
             <script src="js/UpdateBadgeGestion.js"></script>
         <?php
         }
+        if (isset($_GET['GitFolder'])) {
+        ?>
+            <div class="alterbox">
+                <p>During the suppression of your project, a ".git" folder has been found, and can't be delete by this programme. Please do it manualy.</p>
+                <a href="index.php"><i class="fa-solid fa-close"></i></a>
+            </div>
+        <?php
+        }
         ?>
         <div class="Head">
             <img src="img/Logo.png" width="40px" height="40px" class="LogoTitle" />

--- a/post/post_DeleteProject.php
+++ b/post/post_DeleteProject.php
@@ -1,4 +1,7 @@
 <?php
+
+$gitfolder = false; // indicate if a git folder is found.
+
 ///<sumary>
 /// Delete a directory and its content
 ///</sumary>
@@ -15,6 +18,10 @@ function deleteDirectory($dir)
     foreach ($items as $item) {
         if ($item == '.' || $item == '..') {
             continue; // Ignore the special directories
+        }
+
+        if ($item == '.git') {
+            $gitfolder = true;
         }
 
         $path = $dir . DIRECTORY_SEPARATOR . $item;
@@ -37,5 +44,9 @@ $directory = $_GET['ProjectName'];
 deleteDirectory($directory);
 
 // Redirect to the home page
-header('Location: ../index.php');
+if ($gitfolder) {
+    header('Location: ../index.php?GitFolder=True');
+} else {
+    header('Location: ../index.php');
+}
 exit;


### PR DESCRIPTION
The .Git folder need to have administrator authorization to be deleted, so when a project had a .Git folder, an alert will be present on the home page to finish manually the project suppression.